### PR TITLE
add quotes to the with_dict variable as now ansible requires it

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,4 +4,4 @@
 #################################################################
 - name: Setup supervisor config
   template: src=supervisor.conf.j2 dest={{ supervisord_config_location }}/{{ item.value['program_name'] }}.conf
-  with_dict: supervisord_programs
+  with_dict: "{{ supervisord_programs }}"


### PR DESCRIPTION
if the variable under with_dict is unquoted, ansible 2.x will throw error: `with_dict expects a dict`: https://github.com/ansible/ansible/issues/17636